### PR TITLE
Make prebuilt demo downloads easier to find and platform-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ for a small app.
 
 ## Try a prebuilt demo
 
-Download a demo and run it locally. These builds use the `shinylive`
-strategy, so they need nothing installed: download, open, and the app
-runs.
+Each demo is packaged as a desktop app. These are `shinylive` builds, so
+they need no R, Python, or internet: everything runs inside the app.
+Download the installer for your platform, run it, and launch the demo.
+On Linux the download is a portable AppImage you can run straight away.
 
 | Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |
 |----|----|----|----|----|

--- a/README.md
+++ b/README.md
@@ -53,21 +53,18 @@ for a small app.
 
 ## Try a prebuilt demo
 
-Download a demo and run it locally. These builds use the `shinylive`
-strategy, so they need nothing installed: download, open, and the app
+Download the R demo suite and run it locally. It uses the `shinylive`
+strategy, so it needs nothing installed: download, open, and the app
 runs.
 
-| Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |
-|----|----|----|----|----|
-| Python demo suite | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-linux-x64.AppImage) |
-| Python single app | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-linux-x64.AppImage) |
-| R demo suite | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-linux-x64.AppImage) |
-| R single app | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-linux-x64.AppImage) |
+| macOS (Apple) | macOS (Intel) | Windows | Linux |
+|----|----|----|----|
+| [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-linux-x64.AppImage) |
 
-Other strategies (bundled, system, auto-download, container) are
-published too. See the [download-demos
-guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html)
-for the full set and what each one needs, or browse the [releases
+For every demo, platform, and runtime option, see the [Download Prebuilt
+Demos
+guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html),
+or browse the [releases
 page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
 
 ## What you can export

--- a/README.md
+++ b/README.md
@@ -53,18 +53,21 @@ for a small app.
 
 ## Try a prebuilt demo
 
-Download the R demo suite and run it locally. It uses the `shinylive`
-strategy, so it needs nothing installed: download, open, and the app
+Download a demo and run it locally. These builds use the `shinylive`
+strategy, so they need nothing installed: download, open, and the app
 runs.
 
-| macOS (Apple) | macOS (Intel) | Windows | Linux |
-|----|----|----|----|
-| [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-linux-x64.AppImage) |
+| Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |
+|----|----|----|----|----|
+| Python demo suite | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-app-suite-shinylive-linux-x64.AppImage) |
+| Python single app | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-py-single-shinylive-linux-x64.AppImage) |
+| R demo suite | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-r-app-suite-shinylive-linux-x64.AppImage) |
+| R single app | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-mac-arm64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-mac-x64.dmg) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-win-x64.exe) | [download](https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/demo-single-shinylive-linux-x64.AppImage) |
 
-For every demo, platform, and runtime option, see the [Download Prebuilt
-Demos
-guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html),
-or browse the [releases
+Other strategies (bundled, system, auto-download, container) are
+published too. See the [download-demos
+guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html)
+for the full set and what each one needs, or browse the [releases
 page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
 
 ## What you can export

--- a/README.qmd
+++ b/README.qmd
@@ -63,7 +63,7 @@ minute for a small app.
 
 ## Try a prebuilt demo
 
-Download a demo and run it locally. These builds use the `shinylive` strategy, so they need nothing installed: download, open, and the app runs.
+Each demo is packaged as a desktop app. These are `shinylive` builds, so they need no R, Python, or internet: everything runs inside the app. Download the installer for your platform, run it, and launch the demo. On Linux the download is a portable AppImage you can run straight away.
 
 ```{r}
 #| echo: false

--- a/README.qmd
+++ b/README.qmd
@@ -63,31 +63,26 @@ minute for a small app.
 
 ## Try a prebuilt demo
 
-Download a demo and run it locally. These builds use the `shinylive` strategy, so they need nothing installed: download, open, and the app runs.
+Download the R demo suite and run it locally. It uses the `shinylive` strategy, so it needs nothing installed: download, open, and the app runs.
 
 ```{r}
 #| echo: false
 #| results: asis
 m <- shinyelectron:::demo_release_matrix()
 base <- "https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/"
-sl <- m[m$strategy == "shinylive", ]
-demos <- unique(sl[, c("demo", "name")])
-link <- function(d, plat, ar) {
-  row <- sl[sl$demo == d & sl$platform == plat & sl$arch == ar, ]
+sl <- m[m$demo == "demo-r-app-suite" & m$strategy == "shinylive", ]
+link <- function(plat, ar) {
+  row <- sl[sl$platform == plat & sl$arch == ar, ]
   if (nrow(row) == 0) return("--")
   sprintf("[download](%s%s)", base, row$asset_name)
 }
-cat("| Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |\n")
-cat("|------|---------------|---------------|---------|-------|\n")
-for (i in seq_len(nrow(demos))) {
-  d <- demos$demo[i]
-  cat(sprintf("| %s | %s | %s | %s | %s |\n", demos$name[i],
-    link(d, "mac", "arm64"), link(d, "mac", "x64"),
-    link(d, "win", "x64"), link(d, "linux", "x64")))
-}
+cat("| macOS (Apple) | macOS (Intel) | Windows | Linux |\n")
+cat("|---------------|---------------|---------|-------|\n")
+cat(sprintf("| %s | %s | %s | %s |\n",
+  link("mac", "arm64"), link("mac", "x64"), link("win", "x64"), link("linux", "x64")))
 ```
 
-Other strategies (bundled, system, auto-download, container) are published too. See the [download-demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html) for the full set and what each one needs, or browse the [releases page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
+For every demo, platform, and runtime option, see the [Download Prebuilt Demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html), or browse the [releases page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
 
 ## What you can export
 

--- a/README.qmd
+++ b/README.qmd
@@ -63,26 +63,31 @@ minute for a small app.
 
 ## Try a prebuilt demo
 
-Download the R demo suite and run it locally. It uses the `shinylive` strategy, so it needs nothing installed: download, open, and the app runs.
+Download a demo and run it locally. These builds use the `shinylive` strategy, so they need nothing installed: download, open, and the app runs.
 
 ```{r}
 #| echo: false
 #| results: asis
 m <- shinyelectron:::demo_release_matrix()
 base <- "https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/"
-sl <- m[m$demo == "demo-r-app-suite" & m$strategy == "shinylive", ]
-link <- function(plat, ar) {
-  row <- sl[sl$platform == plat & sl$arch == ar, ]
+sl <- m[m$strategy == "shinylive", ]
+demos <- unique(sl[, c("demo", "name")])
+link <- function(d, plat, ar) {
+  row <- sl[sl$demo == d & sl$platform == plat & sl$arch == ar, ]
   if (nrow(row) == 0) return("--")
   sprintf("[download](%s%s)", base, row$asset_name)
 }
-cat("| macOS (Apple) | macOS (Intel) | Windows | Linux |\n")
-cat("|---------------|---------------|---------|-------|\n")
-cat(sprintf("| %s | %s | %s | %s |\n",
-  link("mac", "arm64"), link("mac", "x64"), link("win", "x64"), link("linux", "x64")))
+cat("| Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |\n")
+cat("|------|---------------|---------------|---------|-------|\n")
+for (i in seq_len(nrow(demos))) {
+  d <- demos$demo[i]
+  cat(sprintf("| %s | %s | %s | %s | %s |\n", demos$name[i],
+    link(d, "mac", "arm64"), link(d, "mac", "x64"),
+    link(d, "win", "x64"), link(d, "linux", "x64")))
+}
 ```
 
-For every demo, platform, and runtime option, see the [Download Prebuilt Demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html), or browse the [releases page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
+Other strategies (bundled, system, auto-download, container) are published too. See the [download-demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html) for the full set and what each one needs, or browse the [releases page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
 
 ## What you can export
 

--- a/vignettes/download-demos.qmd
+++ b/vignettes/download-demos.qmd
@@ -72,3 +72,48 @@ for (p in platforms) {
   cat("\n:::\n")
 }
 ```
+
+```{=html}
+<style>
+.detected-platform { margin: 1rem 0 0.25rem; }
+details.more-downloads { margin-top: 1.5rem; }
+details.more-downloads > summary { cursor: pointer; font-weight: 600; }
+</style>
+<script>
+(function () {
+  function detectTarget() {
+    var ua = navigator.userAgent || "";
+    var uaData = navigator.userAgentData;
+    var platStr = ((uaData && uaData.platform) || navigator.platform || "") + " " + ua;
+    var os = /mac/i.test(platStr) ? "mac" : /win/i.test(platStr) ? "win" : /linux|x11/i.test(platStr) ? "linux" : null;
+    if (!os) return Promise.resolve(null);
+    if (os !== "mac") return Promise.resolve(os + "-x64");
+    if (uaData && uaData.getHighEntropyValues) {
+      return uaData.getHighEntropyValues(["architecture"]).then(function (h) {
+        return "mac-" + (h.architecture === "arm" ? "arm64" : "x64");
+      }).catch(function () { return "mac-arm64"; });
+    }
+    return Promise.resolve("mac-arm64");
+  }
+  function organize(targetId) {
+    var blocks = Array.prototype.slice.call(document.querySelectorAll(".platform-block"));
+    if (!blocks.length) return;
+    var target = targetId && document.querySelector('.platform-block[data-platform="' + targetId + '"]');
+    if (!target) return; // detection failed: leave every block visible
+    var label = target.getAttribute("data-label") || targetId;
+    var heading = document.createElement("p");
+    heading.className = "detected-platform";
+    heading.innerHTML = "Showing downloads for: <strong>" + label + "</strong>";
+    target.parentNode.insertBefore(heading, target);
+    var details = document.createElement("details");
+    details.className = "more-downloads";
+    var summary = document.createElement("summary");
+    summary.textContent = "More downloads (other platforms)";
+    details.appendChild(summary);
+    blocks.forEach(function (b) { if (b !== target) details.appendChild(b); });
+    target.parentNode.insertBefore(details, target.nextSibling);
+  }
+  document.addEventListener("DOMContentLoaded", function () { detectTarget().then(organize); });
+})();
+</script>
+```

--- a/vignettes/download-demos.qmd
+++ b/vignettes/download-demos.qmd
@@ -15,14 +15,14 @@ knitr:
 library(shinyelectron)
 ```
 
-Every demo is built with every runtime strategy on each supported platform and published as a release asset. The only gap is the `bundled` and `auto-download` strategies for R on Linux, which have no portable runtime; those cells show `--`. Pick a row, check what it needs, and download.
+Every demo is built with every runtime strategy on each supported platform and published as a release asset. The only gap is the `bundled` and `auto-download` strategies for R on Linux, which have no portable runtime; those cells show `--`.
 
-What each strategy needs on the user's machine:
+Each download is a desktop installer: run it to install the app, then launch the demo. On Linux the download is a portable AppImage you can run directly, with no install step. What changes between strategies is what the app needs once it launches:
 
-- `shinylive`: nothing. The app runs in WebAssembly.
-- `bundled`: nothing. A runtime is embedded in the installer.
+- `shinylive`: no runtime at all. The app runs in WebAssembly, offline.
+- `bundled`: no runtime to install. A copy of R or Python is embedded in the app.
 - `system`: R or Python already installed and on the PATH.
-- `auto-download`: internet access on first launch to fetch the runtime.
+- `auto-download`: internet access on first launch to download the runtime, then cached.
 - `container`: Docker or Podman installed.
 
 Your platform's downloads are shown first. Use **More downloads** for every other platform.
@@ -41,7 +41,7 @@ platforms <- list(
 )
 languages <- list(list(name = "Python", lang = "py"), list(name = "R", lang = "r"))
 groups <- list(
-  list(title = "Standalone (no setup)", strategies = c("shinylive", "bundled")),
+  list(title = "Standalone (no R or Python needed)", strategies = c("shinylive", "bundled")),
   list(title = "Needs a runtime or tooling", strategies = c("system", "auto-download", "container"))
 )
 

--- a/vignettes/download-demos.qmd
+++ b/vignettes/download-demos.qmd
@@ -25,18 +25,50 @@ What each strategy needs on the user's machine:
 - `auto-download`: internet access on first launch to fetch the runtime.
 - `container`: Docker or Podman installed.
 
+Your platform's downloads are shown first. Use **More downloads** for every other platform.
+
 ```{r}
 #| echo: false
 #| results: asis
 m <- shinyelectron:::demo_release_matrix()
 base <- "https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/"
-cat("| Demo | Strategy | Platform | Requirement | Download |\n")
-cat("|------|----------|----------|-------------|----------|\n")
-for (i in seq_len(nrow(m))) {
-  cat(sprintf("| %s | `%s` | %s %s | %s | [%s](%s%s) |\n",
-    m$name[i], m$strategy[i], m$platform[i], m$arch[i],
-    m$requirement[i], m$asset_name[i], base, m$asset_name[i]))
+
+platforms <- list(
+  list(id = "mac-arm64", label = "macOS (Apple Silicon)", platform = "mac", arch = "arm64"),
+  list(id = "mac-x64",   label = "macOS (Intel)",         platform = "mac", arch = "x64"),
+  list(id = "win-x64",   label = "Windows",               platform = "win", arch = "x64"),
+  list(id = "linux-x64", label = "Linux",                 platform = "linux", arch = "x64")
+)
+languages <- list(list(name = "Python", lang = "py"), list(name = "R", lang = "r"))
+groups <- list(
+  list(title = "Standalone (no setup)", strategies = c("shinylive", "bundled")),
+  list(title = "Needs a runtime or tooling", strategies = c("system", "auto-download", "container"))
+)
+
+dl <- function(rows, demo, strat) {
+  r <- rows[rows$demo == demo & rows$strategy == strat, ]
+  if (nrow(r) == 0) return("--")
+  sprintf("[download](%s%s)", base, r$asset_name)
+}
+
+for (p in platforms) {
+  cat(sprintf("\n::: {.platform-block data-platform=\"%s\" data-label=\"%s\"}\n", p$id, p$label))
+  pm <- m[m$platform == p$platform & m$arch == p$arch, ]
+  for (lg in languages) {
+    cat(sprintf("\n## %s\n", lg$name))
+    lm <- pm[pm$language == lg$lang, ]
+    demos <- unique(lm[, c("demo", "name")])
+    for (g in groups) {
+      strs <- g$strategies
+      cat(sprintf("\n### %s\n\n", g$title))
+      cat(paste0("| Demo | ", paste(sprintf("`%s`", strs), collapse = " | "), " |\n"))
+      cat(paste0("|", paste(rep("---", length(strs) + 1), collapse = "|"), "|\n"))
+      for (i in seq_len(nrow(demos))) {
+        cells <- vapply(strs, function(s) dl(lm, demos$demo[i], s), character(1))
+        cat(sprintf("| %s | %s |\n", demos$name[i], paste(cells, collapse = " | ")))
+      }
+    }
+  }
+  cat("\n:::\n")
 }
 ```
-
-All links point at the latest release, so they stay current as new versions are published.

--- a/vignettes/download-demos.qmd
+++ b/vignettes/download-demos.qmd
@@ -15,7 +15,7 @@ knitr:
 library(shinyelectron)
 ```
 
-Every demo is built with every runtime strategy on every supported platform and published as a release asset. Pick a row, check what it needs, and download.
+Every demo is built with every runtime strategy on each supported platform and published as a release asset. The only gap is the `bundled` and `auto-download` strategies for R on Linux, which have no portable runtime; those cells show `--`. Pick a row, check what it needs, and download.
 
 What each strategy needs on the user's machine:
 

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -67,31 +67,7 @@ One call converts the demo to shinylive, wraps it in Electron, builds a distribu
 
 ## Try a prebuilt demo
 
-Prefer to see the result before building your own? Grab a prebuilt demo. These are `shinylive` builds, so they need no R, Python, or internet. Download the installer for your platform, run it, and launch the app. On Linux the download is a portable AppImage you can run directly.
-
-```{r}
-#| echo: false
-#| results: asis
-m <- shinyelectron:::demo_release_matrix()
-base <- "https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/"
-sl <- m[m$strategy == "shinylive", ]
-demos <- unique(sl[, c("demo", "name")])
-link <- function(d, plat, ar) {
-  row <- sl[sl$demo == d & sl$platform == plat & sl$arch == ar, ]
-  if (nrow(row) == 0) return("--")
-  sprintf("[download](%s%s)", base, row$asset_name)
-}
-cat("| Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |\n")
-cat("|------|---------------|---------------|---------|-------|\n")
-for (i in seq_len(nrow(demos))) {
-  d <- demos$demo[i]
-  cat(sprintf("| %s | %s | %s | %s | %s |\n", demos$name[i],
-    link(d, "mac", "arm64"), link(d, "mac", "x64"),
-    link(d, "win", "x64"), link(d, "linux", "x64")))
-}
-```
-
-For every runtime strategy (bundled, system, auto-download, container) and platform, see the [Download Prebuilt Demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html).
+Prefer to see the result before building your own? Grab a prebuilt demo. These are `shinylive` builds, so they need no R, Python, or internet: download the installer for your platform, run it, and launch the app (on Linux the download is a portable AppImage you can run directly). The [Download Prebuilt Demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html) has a build of every demo for every runtime strategy and platform, or you can browse the [releases page](https://github.com/coatless-rpkg/shinyelectron/releases/latest).
 
 ## Export your Shiny app
 

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -65,6 +65,34 @@ export(
 
 One call converts the demo to shinylive, wraps it in Electron, builds a distributable, and launches it. Roughly a minute on a small app.
 
+## Try a prebuilt demo
+
+Prefer to see the result before building your own? Download a ready-to-run demo. These use the `shinylive` strategy, so they need nothing installed.
+
+```{r}
+#| echo: false
+#| results: asis
+m <- shinyelectron:::demo_release_matrix()
+base <- "https://github.com/coatless-rpkg/shinyelectron/releases/latest/download/"
+sl <- m[m$strategy == "shinylive", ]
+demos <- unique(sl[, c("demo", "name")])
+link <- function(d, plat, ar) {
+  row <- sl[sl$demo == d & sl$platform == plat & sl$arch == ar, ]
+  if (nrow(row) == 0) return("--")
+  sprintf("[download](%s%s)", base, row$asset_name)
+}
+cat("| Demo | macOS (Apple) | macOS (Intel) | Windows | Linux |\n")
+cat("|------|---------------|---------------|---------|-------|\n")
+for (i in seq_len(nrow(demos))) {
+  d <- demos$demo[i]
+  cat(sprintf("| %s | %s | %s | %s | %s |\n", demos$name[i],
+    link(d, "mac", "arm64"), link(d, "mac", "x64"),
+    link(d, "win", "x64"), link(d, "linux", "x64")))
+}
+```
+
+For every runtime strategy (bundled, system, auto-download, container) and platform, see the [Download Prebuilt Demos guide](https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/download-demos.html).
+
 ## Export your Shiny app
 
 ### Shinylive: runs in the browser

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -67,7 +67,7 @@ One call converts the demo to shinylive, wraps it in Electron, builds a distribu
 
 ## Try a prebuilt demo
 
-Prefer to see the result before building your own? Download a ready-to-run demo. These use the `shinylive` strategy, so they need nothing installed.
+Prefer to see the result before building your own? Grab a prebuilt demo. These are `shinylive` builds, so they need no R, Python, or internet. Download the installer for your platform, run it, and launch the app. On Linux the download is a portable AppImage you can run directly.
 
 ```{r}
 #| echo: false


### PR DESCRIPTION
The README and getting started guide now feature ready-to-run demo downloads with a link to the full Download Prebuilt Demos guide. That guide is reorganized by language and by whether a build needs any setup, and it detects the visitor's operating system and architecture to show their downloads first while tucking the rest under a More downloads control. Without JavaScript every platform's downloads stay visible. All of the tables are generated from the demo release matrix, so they stay in step with what each release publishes.