### PR TITLE
Switch the bundled GitHub Actions template to the shiny-to-electron action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/build-demos.yml
+++ b/.github/workflows/build-demos.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
@@ -57,7 +57,7 @@ jobs:
       APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
       APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Resolve shinyelectron source ref
         id: src
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload as a workflow artifact
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ steps.collect.outputs.asset }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/inst/templates/github-actions-build.yml
+++ b/inst/templates/github-actions-build.yml
@@ -1,14 +1,14 @@
 # GitHub Actions workflow for building shinyelectron apps
 #
-# This workflow builds your Shiny app as an Electron desktop application
-# for Windows, macOS, and Linux.
+# Builds your Shiny app as an Electron desktop installer for macOS, Windows,
+# and Linux with the coatless-actions/shiny-to-electron action, then attaches
+# the installers to a GitHub Release on version tags.
 #
 # Usage:
-# 1. Copy this file to .github/workflows/build-electron.yml in your repository
-# 2. Ensure your Shiny app is in the 'app/' directory (or update APP_DIR below)
-# 3. Push to trigger the workflow
+# 1. Copy this file to .github/workflows/build-electron.yml in your repository.
+# 2. Set `appdir` (path to your Shiny app) and `app-name` in the build step.
+# 3. Push to build; push a tag like v1.0.0 to also cut a release.
 #
-# For more information, see:
 # https://r-pkg.thecoatlessprofessor.com/shinyelectron/articles/github-actions.html
 
 name: Build Electron App
@@ -20,187 +20,48 @@ on:
   pull_request:
     branches: [main, master]
   workflow_dispatch:
-    inputs:
-      platforms:
-        description: 'Platforms to build (comma-separated: mac,win,linux)'
-        required: false
-        default: 'mac,win,linux'
-
-env:
-  # Configure these for your project
-  APP_DIR: 'app'           # Directory containing your Shiny app
-  APP_NAME: 'MyApp'        # Name of your application
-  NODE_VERSION: '22'       # Node.js version
-  R_VERSION: 'release'     # R version (release, devel, or specific version)
 
 jobs:
   build:
     name: Build (${{ matrix.platform }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
         include:
-          # macOS ARM64 (Apple Silicon)
-          - os: macos-latest
-            platform: mac
-            arch: arm64
-            artifact_ext: dmg
-
-          # macOS x64 (Intel) — macos-15-intel is the current Intel runner
-          - os: macos-15-intel
-            platform: mac
-            arch: x64
-            artifact_ext: dmg
-
-          # Windows x64
-          - os: windows-latest
-            platform: win
-            arch: x64
-            artifact_ext: exe
-
-          # Linux x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: x64
-            artifact_ext: AppImage
-
+          - { os: macos-latest,   platform: mac,   arch: arm64 }
+          - { os: macos-15-intel, platform: mac,   arch: x64 }
+          - { os: windows-latest, platform: win,   arch: x64 }
+          - { os: ubuntu-latest,  platform: linux, arch: x64 }
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+      - name: Build the Electron app
+        uses: coatless-actions/shiny-to-electron@v1
         with:
-          r-version: ${{ env.R_VERSION }}
-          use-public-rspm: true
+          appdir: app                       # Directory containing your Shiny app
+          app-name: MyApp                   # Display name of the application
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          # runtime-strategy: shinylive     # shinylive | bundled | system | auto-download | container
+          # sign: 'false'                   # 'true' with signing secrets to sign and notarize
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
-
-      - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::shinyelectron
-            any::shinylive
-          needs: build
-
-      - name: Verify Shiny app exists
-        run: |
-          if [ ! -d "${{ env.APP_DIR }}" ]; then
-            echo "Error: App directory '${{ env.APP_DIR }}' not found"
-            echo "Please ensure your Shiny app is in the correct directory"
-            exit 1
-          fi
-          echo "Found app directory: ${{ env.APP_DIR }}"
-          ls -la "${{ env.APP_DIR }}"
-        shell: bash
-
-      - name: Build Electron app
-        run: |
-          Rscript -e "
-            library(shinyelectron)
-
-            # Run diagnostics first
-            cat('=== System Diagnostics ===\n')
-            sitrep_electron_system(verbose = TRUE)
-
-            cat('\n=== Building Electron App ===\n')
-            result <- export(
-              appdir = '${{ env.APP_DIR }}',
-              destdir = 'build',
-              app_name = '${{ env.APP_NAME }}',
-              platform = '${{ matrix.platform }}',
-              arch = '${{ matrix.arch }}',
-              overwrite = TRUE,
-              verbose = TRUE
-            )
-
-            cat('\n=== Build Complete ===\n')
-            cat('Output directory:', result[['electron_app']], '\n')
-          "
-        shell: bash
-
-      - name: List build artifacts
-        run: |
-          echo "=== Build output structure ==="
-          find build -type f -name "*.${{ matrix.artifact_ext }}" 2>/dev/null || true
-          ls -laR build/electron-app/dist/ 2>/dev/null || echo "No dist directory found"
-        shell: bash
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.APP_NAME }}-${{ matrix.platform }}-${{ matrix.arch }}
-          path: |
-            build/electron-app/dist/**/*.${{ matrix.artifact_ext }}
-            build/electron-app/dist/**/*.dmg
-            build/electron-app/dist/**/*.exe
-            build/electron-app/dist/**/*.AppImage
-            build/electron-app/dist/**/*.deb
-            build/electron-app/dist/**/*.rpm
-          if-no-files-found: warn
-          retention-days: 30
-
-  # Create a GitHub Release when a version tag is pushed
   release:
     name: Create Release
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
-
     steps:
-      - name: Download all artifacts
+      - name: Download all build artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-
-      - name: Display downloaded artifacts
-        run: |
-          echo "=== Downloaded artifacts ==="
-          find artifacts -type f | head -50
-        shell: bash
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           files: artifacts/**/*
           generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Summary job that reports build status
-  summary:
-    name: Build Summary
-    needs: build
-    if: always()
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check build results
-        run: |
-          echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| macOS (arm64) | ${{ needs.build.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| macOS (x64) | ${{ needs.build.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Windows (x64) | ${{ needs.build.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux (x64) | ${{ needs.build.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}

--- a/inst/templates/github-actions-docker.yml
+++ b/inst/templates/github-actions-docker.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4
@@ -50,7 +50,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4
@@ -74,7 +74,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4

--- a/vignettes/auto-updates.qmd
+++ b/vignettes/auto-updates.qmd
@@ -347,7 +347,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/vignettes/github-actions.qmd
+++ b/vignettes/github-actions.qmd
@@ -14,31 +14,14 @@ knitr:
 #| include: false
 library(shinyelectron)
 
-# Helper: read a labelled block from the bundled workflow so the vignette
-# stays in sync with what shinyelectron actually ships.
-show_template_yaml <- function(anchor_re, max_lines = 200) {
+# Show the bundled workflow verbatim so the vignette stays in sync with what
+# shinyelectron actually ships.
+show_template <- function() {
   path <- system.file(
     "templates", "github-actions-build.yml",
     package = "shinyelectron"
   )
-  lines <- readLines(path)
-  start <- grep(anchor_re, lines)[1]
-  if (is.na(start)) stop("Anchor not found: ", anchor_re)
-
-  # Walk forward while the line is blank or starts with whitespace:
-  # the YAML block ends when we hit the next top-level key.
-  i <- start + 1
-  end <- i
-  while (i <= length(lines) && (i - start) < max_lines) {
-    if (lines[i] == "" || grepl("^\\s+", lines[i]) || grepl("^#", lines[i])) {
-      end <- i
-      i <- i + 1
-    } else {
-      break
-    }
-  }
-
-  cat(c("```yaml", lines[start:end], "```"), sep = "\n")
+  cat(c("```yaml", readLines(path), "```"), sep = "\n")
 }
 ```
 
@@ -81,7 +64,15 @@ my-shiny-project/
 
 ## Use the bundled workflow
 
-shinyelectron ships a ready-to-run workflow at `inst/templates/github-actions-build.yml`. Copy it into your repo:
+shinyelectron ships a ready-to-run workflow at `inst/templates/github-actions-build.yml`. It leans on the [`coatless-actions/shiny-to-electron`](https://github.com/coatless-actions/shiny-to-electron) action, which sets up R and Node.js, installs shinyelectron, runs `export()`, and uploads the installer. That keeps the workflow itself short:
+
+```{r}
+#| echo: false
+#| results: asis
+show_template()
+```
+
+Copy it into your repo:
 
 ```{r}
 #| eval: false
@@ -99,19 +90,11 @@ file.copy(
 
 Or grab it directly from [GitHub](https://github.com/coatless-rpkg/shinyelectron/blob/main/inst/templates/github-actions-build.yml).
 
-The workflow runs three jobs in sequence: a build matrix, a release step gated on tag pushes, and a summary recap.
+Two jobs run: a build matrix across four platform runners, and a release job gated on tag pushes.
 
-### Configure the env vars
+### Configure it
 
-Edit four variables at the top of the workflow. They are the only fields most projects need to change:
-
-```{r}
-#| echo: false
-#| results: asis
-show_template_yaml("^env:")
-```
-
-`APP_DIR` is the path to your Shiny app inside the repo. `APP_NAME` becomes the installer's display name. `NODE_VERSION` and `R_VERSION` pin the toolchain; leave them at the defaults unless you have a reason to deviate.
+Set two things in the build step's `with:` block: `appdir` (the path to your Shiny app inside the repo) and `app-name` (the installer's display name). Everything else has a sensible default. Uncomment `runtime-strategy` to pick a strategy other than `shinylive`, and `sign` to sign builds (see [Signing in CI](#signing-in-ci)).
 
 ### What the matrix builds
 
@@ -126,16 +109,7 @@ The matrix spreads installers across four runners. Each runner starts from a cle
 
 CPU and RAM allocations come from GitHub's hosted-runner specs, which evolve over time; check [the GitHub-hosted runners documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) for current numbers.
 
-Every runner steps through the same recipe:
-
-1. Checkout the repo.
-2. Set up R with `r-lib/actions/setup-r`.
-3. Set up Node.js (version from `NODE_VERSION`).
-4. Install `shinyelectron` and dependencies.
-5. Run `shinyelectron::export()`.
-6. Upload the build output as a run artifact.
-
-A release job runs after the matrix when the trigger is a tag push, downloading every artifact and attaching them to a fresh GitHub Release.
+Each runner does the same two things: check out the repo, then run the action, which sets up R and Node.js, installs shinyelectron, runs `export()` for that platform, and uploads the installer as a run artifact. On a tag push, the release job downloads every artifact and attaches them to a fresh GitHub Release.
 
 ### Push and tag
 
@@ -166,15 +140,17 @@ Drop a badge in your README so contributors see build state at a glance:
 
 ## Customising
 
-The bundled workflow expects most projects to adjust four things: where the app lives, which platforms to ship, what icons to use, and whether to cache R packages aggressively. Each can be edited in place.
+The action exposes an input for most things a project changes. Set them in the build step's `with:` block; anything not listed there falls back to `_shinyelectron.yml` or the defaults.
 
 ### App in a different folder
 
-Override `APP_DIR`:
+Point `appdir` at your app:
 
 ```yaml
-env:
-  APP_DIR: 'src/shiny-app'
+      - uses: coatless-actions/shiny-to-electron@v1
+        with:
+          appdir: src/shiny-app
+          app-name: MyApp
 ```
 
 ### Narrower platform list
@@ -182,132 +158,145 @@ env:
 Trim the matrix to what you ship. Each entry corresponds to one runner; remove the rest:
 
 ```yaml
-strategy:
-  matrix:
-    include:
-      - os: macos-latest
-        platform: mac
-        arch: arm64
-      - os: windows-latest
-        platform: win
-        arch: x64
+    strategy:
+      matrix:
+        include:
+          - { os: macos-latest,   platform: mac, arch: arm64 }
+          - { os: windows-latest, platform: win, arch: x64 }
 ```
 
-### Custom icons
+### Runtime strategy
 
-Ship icons from the repo and pass them to `export()`:
+The default is `shinylive`. Choose another with the `runtime-strategy` input, or set it in `_shinyelectron.yml`:
 
 ```yaml
-- name: Build Electron app
-  run: |
-    Rscript -e "
-      shinyelectron::export(
-        appdir = '${{ env.APP_DIR }}',
-        destdir = 'build',
-        icon = 'assets/icon.icns'
-      )
-    "
+      - uses: coatless-actions/shiny-to-electron@v1
+        with:
+          appdir: app
+          app-name: MyApp
+          runtime-strategy: bundled
 ```
 
-::: {.callout-note}
-Icon requirements: macOS uses `.icns` (build with `iconutil`), Windows uses `.ico` (multi-resolution recommended), Linux uses `.png` at 512x512.
-:::
+### Icons and other options
 
-### Caching R packages
-
-`npm` caching is on by default. R packages are worth caching too:
-
-```yaml
-- name: Setup R
-  uses: r-lib/actions/setup-r@v2
-  with:
-    r-version: ${{ env.R_VERSION }}
-    use-public-rspm: true
-
-- name: Cache R packages
-  uses: actions/cache@v5
-  with:
-    path: ${{ env.R_LIBS_USER }}
-    key: ${{ runner.os }}-r-${{ hashFiles('**/DESCRIPTION') }}
-```
-
-### Config file wins, workflow overrides
-
-A `_shinyelectron.yml` in the app directory is picked up automatically. Workflow parameters passed to `shinyelectron::export()` override its values when set.
+The action does not take an icon input. Put project settings like the icon in a `_shinyelectron.yml` next to your app; `export()` reads it automatically. See the [Configuration Guide](configuration.html) for every option.
 
 ```yaml
 app:
   name: "My Shiny Dashboard"
   version: "1.0.0"
 
-window:
-  width: 1400
-  height: 900
-
 build:
-  type: "r-shiny"
   runtime_strategy: "shinylive"
 ```
 
-## Signing in CI
+### Config file wins, action inputs override
 
-Signing keeps the same `electron-builder` environment variables as a local build, just stored as GitHub Secrets instead. Open Settings, Secrets and variables, Actions, and add each value by name. Reference them from the build job's `env`:
+A `_shinyelectron.yml` in the app directory is picked up automatically. Action inputs override its values when they are set, so you can keep shared settings in the config and vary only the CI-specific ones in the workflow.
 
-```yaml
-- name: Build Electron app
-  env:
-    # macOS
-    CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
-    CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
-    APPLE_ID: ${{ secrets.APPLE_ID }}
-    APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-    # Windows
-    WIN_CSC_LINK: ${{ secrets.WIN_CERTIFICATE }}
-    WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CERTIFICATE_PASSWORD }}
-  run: |
-    Rscript -e "
-      shinyelectron::export(
-        appdir = '${{ env.APP_DIR }}',
-        destdir = 'build',
-        sign = TRUE
-      )
-    "
-```
+## Signing in CI {#signing-in-ci}
 
-::: {.callout-warning}
-Certificates come from Apple (macOS) and a commercial CA (Windows). Unsigned apps trigger Gatekeeper and SmartScreen warnings on end-user machines. See [Code Signing and Distribution](code-signing.html) for the full setup.
-:::
-
-## Coming soon: a composite action
-
-A composite GitHub Action at [`coatless-actions/shiny-to-electron`](https://github.com/coatless-actions/shiny-to-electron) is in development. The goal is to wrap the whole build pipeline so a workflow shrinks to a few lines:
+Signing uses the same `electron-builder` credentials as a local build, stored as GitHub Secrets. Add each under Settings, Secrets and variables, Actions, then pass them to the build job's `env` and flip `sign` on:
 
 ```yaml
-on:
-  push:
-    tags: ['v*']
-jobs:
   build:
     runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CSC_LINK: ${{ secrets.CSC_LINK }}                                  # base64 .p12 signing certificate
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: coatless-actions/shiny-to-electron@v1
         with:
           appdir: app
+          app-name: MyApp
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          sign: 'true'
 ```
 
-The action does not have a published release yet, so the bundled template above is the path to use today. Once the action ships, this section will become the recommended quickstart.
+With `sign: 'true'` and those variables present, macOS builds are signed with your Developer ID and notarized, taking the team id from `APPLE_TEAM_ID`. Leave the credentials out and macOS still falls back to an ad-hoc signature, so the app launches through the standard unidentified-developer prompt rather than reading as damaged.
+
+::: {.callout-warning}
+Certificates come from Apple (macOS) and a commercial CA (Windows). Unsigned apps trigger Gatekeeper and SmartScreen warnings on end-user machines. Storing a signing key in CI means it is decrypted into the runner during the build, so weigh that against how the apps are distributed. See [Code Signing and Distribution](code-signing.html) for the full setup.
+:::
+
+## Roll your own
+
+If you need full control, custom steps, bespoke signing, or extra tooling, skip the action and drive `shinyelectron::export()` yourself. The action is a thin wrapper around exactly this recipe:
+
+```yaml
+jobs:
+  build:
+    name: Build (${{ matrix.platform }}-${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-latest,   platform: mac,   arch: arm64 }
+          - { os: macos-15-intel, platform: mac,   arch: x64 }
+          - { os: windows-latest, platform: win,   arch: x64 }
+          - { os: ubuntu-latest,  platform: linux, arch: x64 }
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            github::coatless-rpkg/shinyelectron
+            any::shinylive
+          needs: build
+
+      - name: Build the Electron app
+        shell: Rscript {0}
+        run: |
+          library(shinyelectron)
+          export(
+            appdir  = "app",
+            destdir = "build",
+            app_name = "MyApp",
+            platform = "${{ matrix.platform }}",
+            arch     = "${{ matrix.arch }}",
+            overwrite = TRUE,
+            verbose   = TRUE
+          )
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: MyApp-${{ matrix.platform }}-${{ matrix.arch }}
+          path: build/electron-app/dist/**
+```
+
+Drive signing from the same `export(sign = TRUE)` call with the `CSC_*` and `APPLE_*` variables in the step's `env`, exactly as above. This is the path to reach for when you want to split building from signing, add caching, or run steps the action does not expose.
 
 ## CI-specific troubleshooting
 
 The general guide in [Troubleshooting](troubleshooting.html) covers symptoms that show up on any machine. The items below are CI-only or turn up much more often on hosted runners than on a developer laptop.
 
+### `appdir` points at the wrong directory
+
+A build fails with `App directory 'app' not found` when your Shiny code lives somewhere other than `app/`. Set the `appdir` input to the actual path.
+
 ### Linux build fails on missing libraries
 
-Hosted Ubuntu runners are minimal. Install whatever system packages your R or Python dependencies need before the build:
+Hosted Ubuntu runners are minimal. If your R or Python dependencies need system packages that the build does not install, add them in your own workflow (the roll-your-own recipe above) before the build step:
 
 ```yaml
 - name: Install system dependencies (Linux)
@@ -317,42 +306,24 @@ Hosted Ubuntu runners are minimal. Install whatever system packages your R or Py
     sudo apt-get install -y libcurl4-openssl-dev libxml2-dev
 ```
 
-### `appdir` points at the wrong directory
+### Pin the shinyelectron version
 
-A workflow that hardcodes `appdir: app` will fail with `App directory 'app' not found` if your repo puts the Shiny code somewhere else. Update `APP_DIR` to match the actual path.
-
-### R package install fails on a runner but not locally
-
-Most often the package is not on CRAN and the workflow never told `setup-r-dependencies` where to find it. Add the repo or the GitHub source explicitly:
+By default the action installs shinyelectron from GitHub. Pin a tag or branch with the `shinyelectron-source` input so a build is reproducible:
 
 ```yaml
-- name: Install R dependencies
-  uses: r-lib/actions/setup-r-dependencies@v2
-  with:
-    extra-packages: |
-      any::shinyelectron
-      github::user/package
+      - uses: coatless-actions/shiny-to-electron@v1
+        with:
+          appdir: app
+          shinyelectron-source: github::coatless-rpkg/shinyelectron@v0.2.0
 ```
 
 ### Job hits the six-hour limit
 
-GitHub-hosted runners cap individual jobs at six hours. If a build comes close, shrink the matrix, cache packages more aggressively, or split the build into separate workflows that run in parallel.
-
-### Run sitrep on the runner
-
-When a build is failing in CI but works on your laptop, run the diagnostic on the runner itself to compare environments:
-
-```yaml
-- name: Run diagnostics
-  run: |
-    Rscript -e "
-      library(shinyelectron)
-      sitrep_shinyelectron()
-    "
-```
+GitHub-hosted runners cap individual jobs at six hours. If a build comes close, shrink the matrix or split the build into separate workflows that run in parallel.
 
 ## Next steps
 
 - [Getting Started](getting-started.html): local development workflow.
 - [Configuration](configuration.html): customize with `_shinyelectron.yml`.
+- [Code Signing](code-signing.html): sign and notarize for distribution.
 - [Troubleshooting](troubleshooting.html): diagnose build issues.


### PR DESCRIPTION
The shipped `inst/templates/github-actions-build.yml` now builds through `coatless-actions/shiny-to-electron@v1` instead of wiring the steps by hand, so the workflow users copy is a short checkout + action + release.

- Rework the GitHub Actions vignette around the action, with a **Roll your own** section showing the equivalent hand-written workflow for full control.
- Document CI signing via the action's `sign` input plus the `CSC_*`/`APPLE_*` secrets (macOS is signed and notarized when they are present).
- Bump `actions/checkout` and `actions/upload-artifact` to their latest versions across the workflows, bundled templates, and vignette examples.