### PR TITLE
Fix siterep_shinyelectron() usage

### DIFF
--- a/R/build-runtime.R
+++ b/R/build-runtime.R
@@ -154,7 +154,7 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
         bundled_rscript, c("-e", r_code),
         error_on_status = FALSE,
         echo = verbose,
-        timeout = 600
+        timeout = 600 * 1000
       )
 
       # Verify every app-direct package is present in the bundled library
@@ -235,7 +235,7 @@ embed_python_runtime <- function(output_dir, packages, index_urls, version,
     pip_result <- processx::run(
       bundled_python, pip_args,
       echo = verbose, spinner = verbose,
-      error_on_status = FALSE, timeout = 600
+      error_on_status = FALSE, timeout = 600 * 1000
     )
     if (pip_result$status != 0) {
       cli::cli_warn(c(

--- a/R/build-steps.R
+++ b/R/build-steps.R
@@ -12,6 +12,7 @@ install_npm_dependencies <- function(output_dir, verbose = TRUE) {
   result <- processx::run(
     command = get_npm_command(),
     args = c("install"),
+    env = nodejs_subprocess_env(),
     wd = output_dir,
     echo = verbose,
     spinner = verbose,
@@ -130,6 +131,7 @@ build_for_platforms <- function(output_dir, platform, arch, sign = FALSE, verbos
         result <- processx::run(
           command = get_npm_command(),
           args = c("run", build_script),
+          env = nodejs_subprocess_env(),
           wd = output_dir,
           echo = FALSE,
           spinner = verbose,
@@ -187,6 +189,7 @@ build_for_platforms <- function(output_dir, platform, arch, sign = FALSE, verbos
         fallback_result <- processx::run(
           command = get_npm_command(),
           args = c("run", platform_script),
+          env = nodejs_subprocess_env(),
           wd = output_dir,
           echo = FALSE,
           spinner = verbose,

--- a/R/convert-python.R
+++ b/R/convert-python.R
@@ -87,7 +87,7 @@ convert_py_to_shinylive <- function(appdir, output_dir, subdir = NULL, overwrite
       echo = verbose,
       spinner = verbose,
       error_on_status = FALSE,
-      timeout = 600
+      timeout = 600 * 1000
     )
 
     if (result$status != 0) {

--- a/R/env.R
+++ b/R/env.R
@@ -48,6 +48,31 @@ get_npm_command <- function(prefer_local = TRUE) {
   }
 }
 
+#' Environment for Node.js and npm child processes
+#'
+#' npm can be launched by its absolute path, but package lifecycle scripts
+#' invoke `node` by name. Ensure a shinyelectron-managed Node.js directory is
+#' therefore also present on PATH for npm and every process it starts.
+#'
+#' @return A named character vector suitable for the `env` argument of
+#'   [processx::run()] and `run_command_safe()`, or NULL when Node.js cannot be
+#'   resolved.
+#' @keywords internal
+nodejs_subprocess_env <- function() {
+  node_cmd <- get_node_command(prefer_local = TRUE)
+  node_path <- if (fs::file_exists(node_cmd)) node_cmd else Sys.which(node_cmd)
+
+  if (!nzchar(node_path)) return(NULL)
+
+  node_dir <- dirname(fs::path_abs(node_path))
+  current_path <- Sys.getenv("PATH")
+  path_entries <- strsplit(current_path, .Platform$path.sep, fixed = TRUE)[[1]]
+
+  if (node_dir %in% path_entries) return(NULL)
+
+  c(PATH = paste(node_dir, current_path, sep = .Platform$path.sep))
+}
+
 #' Set development environment variables
 #'
 #' @param port Integer port number

--- a/R/run.R
+++ b/R/run.R
@@ -87,6 +87,7 @@ run_electron_app <- function(app_dir, port = 3000, open_devtools = TRUE, verbose
     processx::run(
       command = get_npm_command(),
       args = c("run", "electron"),
+      env = nodejs_subprocess_env(),
       wd = app_dir,
       echo = verbose,
       echo_cmd = verbose,

--- a/R/sitrep-system.R
+++ b/R/sitrep-system.R
@@ -101,7 +101,10 @@ sitrep_electron_system <- function(verbose = TRUE) {
   }
 
   # Check npm
-  npm_result <- run_command_safe(get_npm_command(), "--version")
+  npm_result <- run_command_safe(
+    get_npm_command(), "--version",
+    env = nodejs_subprocess_env()
+  )
 
   if (npm_result$status == 0) {
     results$npm$installed <- TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,20 +96,54 @@ validate_slug <- function(slug) {
 }
 #' Run a command safely and return the result
 #'
-#' Wraps processx::run with consistent error handling. Returns a list
+#' Wraps [base::system2()] with consistent error handling. The diagnostic
+#' probes deliberately use base R rather than processx so that a failure to
+#' start or stop an external program cannot abort the host RStudio session.
+#' Returns a list
 #' with status, stdout, and stderr. Never throws; failures are
 #' indicated by a non-zero status.
 #'
 #' @param command Character command to run.
 #' @param args Character vector of arguments.
 #' @param timeout Numeric timeout in seconds. Default 30.
+#' @param env Optional named character vector of environment variables.
 #' @return List with status, stdout, stderr.
 #' @keywords internal
-run_command_safe <- function(command, args = character(), timeout = 30) {
-  tryCatch(
-    processx::run(command, args, error_on_status = FALSE, timeout = timeout),
-    error = function(e) list(status = 1L, stdout = "", stderr = e$message)
-  )
+run_command_safe <- function(command, args = character(), timeout = 30,
+                             env = NULL) {
+  stdout_file <- tempfile("shinyelectron-stdout-")
+  stderr_file <- tempfile("shinyelectron-stderr-")
+  on.exit(unlink(c(stdout_file, stderr_file)), add = TRUE)
+
+  tryCatch({
+    system2_env <- env
+    if (!is.null(system2_env) && !is.null(names(system2_env))) {
+      system2_env <- paste0(names(system2_env), "=", system2_env)
+    }
+
+    status <- suppressWarnings(system2(
+      command,
+      vapply(args, shQuote, character(1)),
+      stdout = stdout_file,
+      stderr = stderr_file,
+      wait = TRUE,
+      timeout = timeout,
+      env = system2_env
+    ))
+
+    read_output <- function(path) {
+      if (!file.exists(path) || file.info(path)$size == 0) return("")
+      paste(readLines(path, warn = FALSE), collapse = "\n")
+    }
+
+    list(
+      status = as.integer(status %||% 0L),
+      stdout = read_output(stdout_file),
+      stderr = read_output(stderr_file)
+    )
+  }, error = function(e) {
+    list(status = 1L, stdout = "", stderr = conditionMessage(e))
+  })
 }
 #' Locate Rscript inside a bundled portable-R runtime directory
 #'
@@ -213,6 +247,9 @@ find_python_command <- function() {
 #'   [processx::run()].
 #' @keywords internal
 python_subprocess_env <- function() {
+  if (is.na(Sys.getenv("LD_LIBRARY_PATH", unset = NA_character_))) {
+    return(NULL)
+  }
   env <- Sys.getenv()
   env[!names(env) %in% "LD_LIBRARY_PATH"]
 }

--- a/R/validate-container.R
+++ b/R/validate-container.R
@@ -18,7 +18,7 @@ validate_container_available <- function(preference = NULL) {
 
   tryCatch({
     result <- processx::run(engine, c("info"),
-                            error_on_status = FALSE, timeout = 15)
+                            error_on_status = FALSE, timeout = 15 * 1000)
     if (result$status != 0) {
       cli::cli_abort(c(
         "{.strong {engine}} is installed but not running",

--- a/R/validate-node.R
+++ b/R/validate-node.R
@@ -20,7 +20,10 @@ validate_node_npm <- function() {
     ))
   }
 
-  npm_result <- run_command_safe(npm_cmd, "--version")
+  npm_result <- run_command_safe(
+    npm_cmd, "--version",
+    env = nodejs_subprocess_env()
+  )
 
   if (npm_result$status != 0) {
     cli::cli_abort(c(

--- a/R/validate-python.R
+++ b/R/validate-python.R
@@ -27,10 +27,10 @@ validate_python_available <- function() {
 validate_python_shinylive_installed <- function() {
   shinylive_cmd <- Sys.which("shinylive")
   if (nzchar(shinylive_cmd)) {
-    result <- processx::run(
+    result <- run_command_safe(
       "shinylive", c("--version"),
       env = python_subprocess_env(),
-      error_on_status = FALSE, timeout = 30
+      timeout = 30
     )
     cmd_label <- "shinylive"
   } else {
@@ -38,10 +38,10 @@ validate_python_shinylive_installed <- function() {
     if (is.null(python_cmd)) {
       cli::cli_abort("Python is required but was not found")
     }
-    result <- processx::run(
+    result <- run_command_safe(
       python_cmd, c("-m", "shinylive", "--version"),
       env = python_subprocess_env(),
-      error_on_status = FALSE, timeout = 30
+      timeout = 30
     )
     cmd_label <- paste(python_cmd, "-m shinylive")
   }
@@ -85,11 +85,10 @@ validate_python_shiny_installed <- function() {
     cli::cli_abort("Python is required but was not found")
   }
 
-  result <- processx::run(
+  result <- run_command_safe(
     python_cmd,
     c("-c", "import shiny; print(shiny.__version__)"),
     env = python_subprocess_env(),
-    error_on_status = FALSE,
     timeout = 30
   )
 


### PR DESCRIPTION
Running sitrep_shinyelectron() caused RStudio to immediately crash. Windows user. Used codex to fix the issue.