### PR TITLE
Add GitHub and local R package support for bundled apps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # shinyelectron 0.2.0
 
+* Bundled R builds now accept pak-style GitHub package references in
+  `dependencies.r.packages`, including pinned refs and explicit package-name
+  aliases such as `mypkg=github::owner/repository@v1.2.0`.
+
 This release grows shinyelectron from an R shinylive exporter into a general
 Shiny-to-desktop toolkit, adding Python apps, five runtime strategies, and
 multi-app suites.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # shinyelectron 0.2.0
 
-* Bundled R builds now accept pak-style GitHub package references in
+* Bundled R builds now accept pak-style GitHub and local package references in
   `dependencies.r.packages`, including pinned refs and explicit package-name
-  aliases such as `mypkg=github::owner/repository@v1.2.0`.
+  aliases such as `mypkg=github::owner/repository@v1.2.0`. Relative local
+  paths are resolved from the Shiny app directory and embedded at build time.
 
 This release grows shinyelectron from an R shinylive exporter into a general
 Shiny-to-desktop toolkit, adding Python apps, five runtime strategies, and

--- a/R/build-runtime.R
+++ b/R/build-runtime.R
@@ -91,9 +91,9 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
 
     pkgs <- unlist(packages)
     repos <- unlist(repos)
-    github_specs <- pkgs[is_github_r_package(pkgs)]
-    github_names <- github_r_package_name(github_specs)
-    cran_pkgs <- pkgs[!is_github_r_package(pkgs)]
+    pak_specs <- pkgs[is_pak_r_package(pkgs)]
+    pak_names <- r_package_name(pak_specs)
+    cran_pkgs <- pkgs[!is_pak_r_package(pkgs)]
 
     # Fetch the available-packages database once (avoids repeated CRAN network
     # calls). A GitHub-only dependency set does not need this index at all.
@@ -115,13 +115,13 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
     pre_installed <- list.dirs(lib_path, recursive = FALSE, full.names = FALSE)
     pre_installed <- pre_installed[nzchar(pre_installed)]
     all_pkgs <- setdiff(all_pkgs, pre_installed)
-    github_specs <- github_specs[!github_names %in% pre_installed]
+    pak_specs <- pak_specs[!pak_names %in% pre_installed]
 
-    if (length(all_pkgs) == 0 && length(github_specs) == 0) {
+    if (length(all_pkgs) == 0 && length(pak_specs) == 0) {
       if (verbose) cli::cli_alert_info("All dependencies already present in bundled R library")
     } else {
       if (verbose) {
-        install_count <- length(all_pkgs) + length(github_specs)
+        install_count <- length(all_pkgs) + length(pak_specs)
         cli::cli_alert_info("Installing {install_count} package{?s} into bundled library")
       }
 
@@ -155,7 +155,7 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
           r_literal(all_pkgs), lib_literal, repo_literal, type_clause
         ))
       }
-      if (length(github_specs) > 0) {
+      if (length(pak_specs) > 0) {
         r_steps <- c(
           r_steps,
           sprintf(
@@ -173,7 +173,7 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
           ),
           sprintf(
             "pak::pkg_install(%s, lib = %s, dependencies = NA, upgrade = FALSE, ask = FALSE)",
-            r_literal(github_specs), lib_literal
+            r_literal(pak_specs), lib_literal
           )
         )
       }
@@ -195,7 +195,7 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
       # than "no package called 'htmltools'" from a running Shiny server.
       present <- c(pre_installed,
                    list.dirs(lib_path, recursive = FALSE, full.names = FALSE))
-      expected_pkgs <- unique(c(cran_pkgs, github_names))
+      expected_pkgs <- unique(c(cran_pkgs, pak_names))
       missing_pkgs <- setdiff(expected_pkgs, present)
       if (length(missing_pkgs) > 0) {
         cli::cli_abort(c(

--- a/R/build-runtime.R
+++ b/R/build-runtime.R
@@ -91,18 +91,22 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
 
     pkgs <- unlist(packages)
     repos <- unlist(repos)
+    github_specs <- pkgs[is_github_r_package(pkgs)]
+    github_names <- github_r_package_name(github_specs)
+    cran_pkgs <- pkgs[!is_github_r_package(pkgs)]
 
-    # Fetch the available-packages database once (avoids repeated
-    # CRAN network calls during the same export session).
-    avail_pkgs <- utils::available.packages(repos = repos)
-
-    # Resolve full dependency tree
-    all_deps <- tools::package_dependencies(
-      pkgs, db = avail_pkgs,
-      which = c("Depends", "Imports", "LinkingTo"),
-      recursive = TRUE
-    )
-    all_pkgs <- unique(c(pkgs, unlist(all_deps)))
+    # Fetch the available-packages database once (avoids repeated CRAN network
+    # calls). A GitHub-only dependency set does not need this index at all.
+    all_deps <- list()
+    if (length(cran_pkgs) > 0) {
+      avail_pkgs <- utils::available.packages(repos = repos)
+      all_deps <- tools::package_dependencies(
+        cran_pkgs, db = avail_pkgs,
+        which = c("Depends", "Imports", "LinkingTo"),
+        recursive = TRUE
+      )
+    }
+    all_pkgs <- unique(c(cran_pkgs, unlist(all_deps)))
 
     # Skip packages already present in the bundled library. Portable-R
     # ships with base + recommended + a few extras; reinstalling them is
@@ -111,16 +115,19 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
     pre_installed <- list.dirs(lib_path, recursive = FALSE, full.names = FALSE)
     pre_installed <- pre_installed[nzchar(pre_installed)]
     all_pkgs <- setdiff(all_pkgs, pre_installed)
+    github_specs <- github_specs[!github_names %in% pre_installed]
 
-    if (length(all_pkgs) == 0) {
+    if (length(all_pkgs) == 0 && length(github_specs) == 0) {
       if (verbose) cli::cli_alert_info("All dependencies already present in bundled R library")
     } else {
       if (verbose) {
-        cli::cli_alert_info("Installing {length(all_pkgs)} package{?s} into bundled library")
+        install_count <- length(all_pkgs) + length(github_specs)
+        cli::cli_alert_info("Installing {install_count} package{?s} into bundled library")
       }
 
-      pkg_str <- paste0("'", all_pkgs, "'", collapse = ", ")
-      repo_str <- paste0("'", repos, "'", collapse = ", ")
+      r_literal <- function(x) {
+        paste(deparse(as.character(x), width.cutoff = 500L), collapse = "")
+      }
       # type = "binary" is unsupported on Linux (.Platform$pkgType ==
       # "source"); only request it on the platforms that accept it.
       # Keyed on the build HOST pkgType (detect_current_platform()), not the
@@ -130,21 +137,47 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
       } else {
         "type = 'binary', "
       }
-      # Use the bundled library as both destination AND the only lib on
-      # .libPaths, which avoids install.packages getting confused by
-      # packages the caller's R_LIBS_USER may have inherited.
-      r_code <- sprintf(
-        paste0(
-          ".libPaths('%s'); ",
-          "install.packages(c(%s), lib = '%s', repos = c(%s), ",
-          "%sdependencies = FALSE, quiet = TRUE)"
-        ),
-        gsub("\\\\", "/", lib_path),
-        pkg_str,
-        gsub("\\\\", "/", lib_path),
-        repo_str,
-        type_clause
+      # Use the bundled library as both destination AND the first lib on
+      # .libPaths. GitHub references are installed with pak; ordinary package
+      # names retain the existing install.packages path.
+      lib_literal <- r_literal(gsub("\\\\", "/", lib_path))
+      repo_literal <- r_literal(repos)
+      r_steps <- c(
+        sprintf(".libPaths(%s)", lib_literal),
+        sprintf("options(repos = %s)", repo_literal)
       )
+      if (length(all_pkgs) > 0) {
+        r_steps <- c(r_steps, sprintf(
+          paste0(
+            "install.packages(%s, lib = %s, repos = %s, ",
+            "%sdependencies = FALSE, quiet = TRUE)"
+          ),
+          r_literal(all_pkgs), lib_literal, repo_literal, type_clause
+        ))
+      }
+      if (length(github_specs) > 0) {
+        r_steps <- c(
+          r_steps,
+          sprintf(
+            paste0(
+              "if (!requireNamespace('pak', quietly = TRUE, lib.loc = %s)) ",
+              "install.packages('pak', lib = %s, repos = %s, %squiet = TRUE)"
+            ),
+            lib_literal, lib_literal, repo_literal, type_clause
+          ),
+          sprintf(
+            paste0(
+              "if (!nzchar(Sys.getenv('GITHUB_PAT')) && nzchar(Sys.getenv('GH_TOKEN'))) ",
+              "Sys.setenv(GITHUB_PAT = Sys.getenv('GH_TOKEN'))"
+            )
+          ),
+          sprintf(
+            "pak::pkg_install(%s, lib = %s, dependencies = NA, upgrade = FALSE, ask = FALSE)",
+            r_literal(github_specs), lib_literal
+          )
+        )
+      }
+      r_code <- paste(r_steps, collapse = "; ")
 
       # Pre-session code didn't scrub env or pass --vanilla and worked
       # fine -- the bundled library being a sibling (not the R's own
@@ -162,7 +195,8 @@ embed_r_runtime <- function(output_dir, packages, repos, version,
       # than "no package called 'htmltools'" from a running Shiny server.
       present <- c(pre_installed,
                    list.dirs(lib_path, recursive = FALSE, full.names = FALSE))
-      missing_pkgs <- setdiff(pkgs, present)
+      expected_pkgs <- unique(c(cran_pkgs, github_names))
+      missing_pkgs <- setdiff(expected_pkgs, present)
       if (length(missing_pkgs) > 0) {
         cli::cli_abort(c(
           "Failed to install bundled R packages: {paste(missing_pkgs, collapse = ', ')}",

--- a/R/build.R
+++ b/R/build.R
@@ -162,7 +162,9 @@ build_electron_app <- function(app_dir, output_dir, app_name = NULL, app_type = 
       if (fs::file_exists(dep_manifest_path)) {
         dep_manifest <- jsonlite::fromJSON(dep_manifest_path, simplifyVector = FALSE)
         if (identical(dep_manifest$language, "r")) {
-          packages <- unlist(dep_manifest$packages)
+          packages <- unlist(
+            dep_manifest$package_sources %||% dep_manifest$packages
+          )
           repos <- unlist(dep_manifest$repos)
         }
       }
@@ -175,6 +177,9 @@ build_electron_app <- function(app_dir, output_dir, app_name = NULL, app_type = 
         arch = arch[1],
         verbose = verbose
       )
+      # GitHub/local references are needed only while constructing the bundled
+      # library. Ship ordinary package names to the runtime dependency checker.
+      strip_dependency_package_sources(dep_manifest_path)
     }
 
     if (runtime_strategy == "bundled" && grepl("^py-", app_type)) {

--- a/R/dependencies-r.R
+++ b/R/dependencies-r.R
@@ -8,6 +8,31 @@ BASE_R_PACKAGES <- c(
   "spatial", "survival"
 )
 
+#' Identify a GitHub R package reference
+#'
+#' Supports pak-style references such as `github::owner/repo`, an optional
+#' ref (`@v1.2.0`), and an optional package-name alias
+#' (`mypkg=github::owner/repo`).
+#' @keywords internal
+is_github_r_package <- function(x) {
+  grepl("^(?:[^=]+[=])?(?:github::|https?://github[.]com/)", x,
+        perl = TRUE)
+}
+
+#' Infer the installed package name from a GitHub package reference
+#' @keywords internal
+github_r_package_name <- function(x) {
+  aliased <- grepl("=", x, fixed = TRUE)
+  alias <- ifelse(aliased, sub("=.*$", "", x), NA_character_)
+  ref <- sub("^[^=]+=", "", x)
+  ref <- sub("^github::", "", ref)
+  ref <- sub("^https?://github[.]com/", "", ref)
+  ref <- sub("[?#].*$", "", ref)
+  ref <- sub("@[^/]*$", "", ref)
+  repo <- basename(ref)
+  ifelse(aliased, alias, repo)
+}
+
 #' Detect R package dependencies from source files
 #'
 #' Uses `renv::dependencies()` to scan R source files for package
@@ -57,6 +82,11 @@ merge_r_dependencies <- function(detected, config_deps) {
 
   declared <- unlist(config_deps$r$packages %||% list())
   extra <- unlist(config_deps$extra_packages %||% list())
+
+  github_specs <- c(declared, extra)
+  github_specs <- github_specs[is_github_r_package(github_specs)]
+  github_names <- github_r_package_name(github_specs)
+  detected <- setdiff(detected, github_names)
 
   packages <- if (isTRUE(config_deps$auto_detect %||% TRUE)) {
     sort(unique(c(detected, declared, extra)))

--- a/R/dependencies-r.R
+++ b/R/dependencies-r.R
@@ -19,6 +19,18 @@ is_github_r_package <- function(x) {
         perl = TRUE)
 }
 
+#' Identify a local R package reference
+#' @keywords internal
+is_local_r_package <- function(x) {
+  grepl("^[^=]+[=]local::", x)
+}
+
+#' Identify an R package reference installed by pak
+#' @keywords internal
+is_pak_r_package <- function(x) {
+  is_github_r_package(x) | is_local_r_package(x)
+}
+
 #' Infer the installed package name from a GitHub package reference
 #' @keywords internal
 github_r_package_name <- function(x) {
@@ -31,6 +43,43 @@ github_r_package_name <- function(x) {
   ref <- sub("@[^/]*$", "", ref)
   repo <- basename(ref)
   ifelse(aliased, alias, repo)
+}
+
+#' Return the installed package name for any supported package declaration
+#' @keywords internal
+r_package_name <- function(x) {
+  result <- x
+  pak_ref <- is_pak_r_package(x)
+  result[pak_ref] <- ifelse(
+    is_local_r_package(x[pak_ref]),
+    sub("=.*$", "", x[pak_ref]),
+    github_r_package_name(x[pak_ref])
+  )
+  result
+}
+
+#' Resolve local package paths relative to the Shiny application
+#' @keywords internal
+resolve_local_r_packages <- function(packages, appdir) {
+  local <- is_local_r_package(packages)
+  if (!any(local)) return(packages)
+
+  packages[local] <- vapply(packages[local], function(spec) {
+    package_name <- sub("=.*$", "", spec)
+    package_path <- sub("^[^=]+[=]local::", "", spec)
+    if (!fs::is_absolute_path(package_path)) {
+      package_path <- fs::path(appdir, package_path)
+    }
+    package_path <- fs::path_abs(package_path)
+    if (!fs::file_exists(package_path) && !fs::dir_exists(package_path)) {
+      cli::cli_abort(c(
+        "Local R package does not exist: {.path {package_path}}",
+        "i" = "Local package paths are resolved relative to {.path {appdir}}."
+      ))
+    }
+    paste0(package_name, "=local::", gsub("\\\\", "/", package_path))
+  }, character(1))
+  packages
 }
 
 #' Detect R package dependencies from source files
@@ -83,10 +132,9 @@ merge_r_dependencies <- function(detected, config_deps) {
   declared <- unlist(config_deps$r$packages %||% list())
   extra <- unlist(config_deps$extra_packages %||% list())
 
-  github_specs <- c(declared, extra)
-  github_specs <- github_specs[is_github_r_package(github_specs)]
-  github_names <- github_r_package_name(github_specs)
-  detected <- setdiff(detected, github_names)
+  pak_specs <- c(declared, extra)
+  pak_specs <- pak_specs[is_pak_r_package(pak_specs)]
+  detected <- setdiff(detected, r_package_name(pak_specs))
 
   packages <- if (isTRUE(config_deps$auto_detect %||% TRUE)) {
     sort(unique(c(detected, declared, extra)))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -57,12 +57,21 @@ query_sysreqs <- function(pkgs, distribution = "ubuntu", release = "24.04") {
 #' @keywords internal
 generate_dependency_manifest <- function(packages, language,
                                          repos = NULL, index_urls = NULL) {
+  package_sources <- packages
+  runtime_packages <- packages
+  if (language == "r") {
+    runtime_packages <- r_package_name(packages)
+  }
   manifest <- list(
     schema_version = MANIFEST_SCHEMA_VERSION,
     language = language,
-    packages = as.list(packages),
+    packages = as.list(runtime_packages),
     binary_only = TRUE
   )
+
+  if (language == "r" && any(package_sources != runtime_packages)) {
+    manifest$package_sources <- as.list(package_sources)
+  }
 
   if (language == "r") {
     manifest$repos <- repos %||% SHINYELECTRON_DEFAULTS$dependencies$r$repos
@@ -75,9 +84,9 @@ generate_dependency_manifest <- function(packages, language,
   # distribution per call, so query Debian/Ubuntu and Fedora/RedHat separately.
   # as.list() forces JSON array shape so the JS consumer can iterate even when
   # a distro has exactly one system package.
-  cran_packages <- packages
+  cran_packages <- package_sources
   if (language == "r") {
-    cran_packages <- packages[!is_github_r_package(packages)]
+    cran_packages <- package_sources[!is_pak_r_package(package_sources)]
   }
   if (language == "r" && length(cran_packages) > 0) {
     manifest$system_deps <- list(
@@ -87,6 +96,20 @@ generate_dependency_manifest <- function(packages, language,
   }
 
   jsonlite::toJSON(manifest, pretty = TRUE, auto_unbox = TRUE)
+}
+
+#' Remove build-only package source references from a dependency manifest
+#' @keywords internal
+strip_dependency_package_sources <- function(path) {
+  if (!fs::file_exists(path)) return(invisible(FALSE))
+  manifest <- jsonlite::fromJSON(path, simplifyVector = FALSE)
+  if (is.null(manifest$package_sources)) return(invisible(FALSE))
+  manifest$package_sources <- NULL
+  writeLines(
+    jsonlite::toJSON(manifest, pretty = TRUE, auto_unbox = TRUE),
+    path
+  )
+  invisible(TRUE)
 }
 
 #' Resolve application dependencies
@@ -112,12 +135,13 @@ resolve_app_dependencies <- function(appdir, app_type, runtime_strategy, config)
   if (grepl("^r-", app_type)) {
     detected <- detect_r_dependencies(appdir)
     merged <- merge_r_dependencies(detected, config_deps)
-    github_specs <- merged$packages[is_github_r_package(merged$packages)]
-    if (length(github_specs) > 0 && runtime_strategy != "bundled") {
+    merged$packages <- resolve_local_r_packages(merged$packages, appdir)
+    pak_specs <- merged$packages[is_pak_r_package(merged$packages)]
+    if (length(pak_specs) > 0 && runtime_strategy != "bundled") {
       cli::cli_abort(c(
-        "GitHub R packages currently require the bundled runtime strategy",
+        "GitHub and local R packages currently require the bundled runtime strategy",
         "i" = "Set {.code runtime_strategy = \"bundled\"} in {.code export()}.",
-        "i" = "GitHub package: {github_specs[1]}"
+        "i" = "Package source: {pak_specs[1]}"
       ))
     }
     list(

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -75,10 +75,14 @@ generate_dependency_manifest <- function(packages, language,
   # distribution per call, so query Debian/Ubuntu and Fedora/RedHat separately.
   # as.list() forces JSON array shape so the JS consumer can iterate even when
   # a distro has exactly one system package.
-  if (language == "r" && length(packages) > 0) {
+  cran_packages <- packages
+  if (language == "r") {
+    cran_packages <- packages[!is_github_r_package(packages)]
+  }
+  if (language == "r" && length(cran_packages) > 0) {
     manifest$system_deps <- list(
-      debian = as.list(query_sysreqs(packages, "ubuntu", "24.04")),
-      fedora = as.list(query_sysreqs(packages, "redhat", "9"))
+      debian = as.list(query_sysreqs(cran_packages, "ubuntu", "24.04")),
+      fedora = as.list(query_sysreqs(cran_packages, "redhat", "9"))
     )
   }
 
@@ -108,6 +112,14 @@ resolve_app_dependencies <- function(appdir, app_type, runtime_strategy, config)
   if (grepl("^r-", app_type)) {
     detected <- detect_r_dependencies(appdir)
     merged <- merge_r_dependencies(detected, config_deps)
+    github_specs <- merged$packages[is_github_r_package(merged$packages)]
+    if (length(github_specs) > 0 && runtime_strategy != "bundled") {
+      cli::cli_abort(c(
+        "GitHub R packages currently require the bundled runtime strategy",
+        "i" = "Set {.code runtime_strategy = \"bundled\"} in {.code export()}.",
+        "i" = "GitHub package: {github_specs[1]}"
+      ))
+    }
     list(
       language = "r",
       packages = merged$packages,

--- a/R/export-multi.R
+++ b/R/export-multi.R
@@ -348,6 +348,14 @@ build_multi_app <- function(apps_dir, output_dir, app_name,
       arch = arch[1],
       verbose = verbose
     )
+    for (manifest_path in fs::dir_ls(
+      src_apps_dir,
+      recurse = TRUE,
+      regexp = "dependencies[.]json$",
+      type = "file"
+    )) {
+      strip_dependency_package_sources(manifest_path)
+    }
   }
   if (py_bundled) {
     if (verbose) cli::cli_alert_info("Embedding Python runtime for bundled apps...")

--- a/R/manifest-schemas.R
+++ b/R/manifest-schemas.R
@@ -20,6 +20,7 @@
 #'   "schema_version": "2",
 #'   "language": "r" | "python",
 #'   "packages": ["shiny", "bslib", ...],
+#'   "package_sources": ["shiny", "mypkg=github::owner/repo"], // optional, R build only
 #'   "binary_only": true,
 #'   "repos": ["https://cloud.r-project.org"],       // R only
 #'   "index_urls": ["https://pypi.org/simple"],      // Python only

--- a/README.md
+++ b/README.md
@@ -24,6 +24,51 @@ users double-click to open.
 > not yet on CRAN and may have rough edges. **Not recommended for
 > production applications at this time.**
 
+## Private and local R packages
+
+R packages do not need to be published on CRAN to ship with a desktop app.
+With `runtime_strategy = "bundled"`, shinyelectron can install packages
+directly from GitHub or the build machine and embed them in the app's private R
+library. End users do not need R, the original package directory, repository
+access, or credentials. Bundling is distribution, not source-code protection:
+installed package contents remain inspectable by a determined user.
+
+Declare package sources in `_shinyelectron.yml` beside `app.R`:
+
+``` yaml
+dependencies:
+  r:
+    packages:
+      # Public GitHub repository; @ref may be a branch, tag, or commit
+      - github::owner/package@v1.2.0
+
+      # Use an alias when the repository and R package names differ
+      - internaltools=github::company/internal-tools@main
+
+      # Resolved relative to the Shiny app directory
+      - localmodel=local::../packages/localmodel
+
+      # A versioned local source archive works too
+      - reporting=local::../packages/reporting_2.1.0.tar.gz
+```
+
+Build these apps with the bundled strategy:
+
+``` r
+export(
+  appdir = "path/to/shiny-app",
+  destdir = "path/to/output",
+  runtime_strategy = "bundled"
+)
+```
+
+Public GitHub and local packages require no credentials. Private GitHub
+repositories use `GITHUB_PAT` or `GH_TOKEN` from the build environment.
+Tokens are build-time secrets: they are not required by end users and must
+never be placed in app source, `_shinyelectron.yml`, or an installer.
+Relative local paths and pinned source archives are the simplest reproducible
+option for internal or corporate builds.
+
 ## Install
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -33,7 +33,23 @@ library. End users do not need R, the original package directory, repository
 access, or credentials. Bundling is distribution, not source-code protection:
 installed package contents remain inspectable by a determined user.
 
-Declare package sources in `_shinyelectron.yml` beside `app.R`:
+For example, a Windows user might keep an app and two unpublished packages in
+one project:
+
+``` text
+C:/Users/alex/Documents/acme-desktop/
+|-- shiny-app/
+|   |-- app.R
+|   `-- _shinyelectron.yml
+|-- packages/
+|   |-- acmeData/
+|   |   |-- DESCRIPTION
+|   |   `-- R/
+|   `-- acmeReports_2.1.0.tar.gz
+`-- builds/
+```
+
+The fake `shiny-app/_shinyelectron.yml` would look like this:
 
 ``` yaml
 dependencies:
@@ -43,24 +59,33 @@ dependencies:
       - github::owner/package@v1.2.0
 
       # Use an alias when the repository and R package names differ
-      - internaltools=github::company/internal-tools@main
+      - acmeTheme=github::acme-corp/acme-shiny-theme@main
 
       # Resolved relative to the Shiny app directory
-      - localmodel=local::../packages/localmodel
+      - acmeData=local::../packages/acmeData
 
       # A versioned local source archive works too
-      - reporting=local::../packages/reporting_2.1.0.tar.gz
+      - acmeReports=local::../packages/acmeReports_2.1.0.tar.gz
 ```
 
-Build these apps with the bundled strategy:
+The user can then build from any R working directory by using explicit paths:
 
 ``` r
+project_dir <- "C:/Users/alex/Documents/acme-desktop"
+
 export(
-  appdir = "path/to/shiny-app",
-  destdir = "path/to/output",
-  runtime_strategy = "bundled"
+  appdir = file.path(project_dir, "shiny-app"),
+  destdir = file.path(project_dir, "builds", "acme-desktop-app"),
+  app_name = "Acme Analytics",
+  runtime_strategy = "bundled",
+  overwrite = TRUE
 )
 ```
+
+The `local::../packages/...` paths are evaluated from `shiny-app`, where the
+YAML file lives, not from the current R working directory. The resulting Windows
+installer is written beneath
+`builds/acme-desktop-app/electron-app/dist/`.
 
 Public GitHub and local packages require no credentials. Private GitHub
 repositories use `GITHUB_PAT` or `GH_TOKEN` from the build environment.

--- a/README.qmd
+++ b/README.qmd
@@ -43,7 +43,23 @@ library. End users do not need R, the original package directory, repository
 access, or credentials. Bundling is distribution, not source-code protection:
 installed package contents remain inspectable by a determined user.
 
-Declare package sources in `_shinyelectron.yml` beside `app.R`:
+For example, a Windows user might keep an app and two unpublished packages in
+one project:
+
+```text
+C:/Users/alex/Documents/acme-desktop/
+|-- shiny-app/
+|   |-- app.R
+|   `-- _shinyelectron.yml
+|-- packages/
+|   |-- acmeData/
+|   |   |-- DESCRIPTION
+|   |   `-- R/
+|   `-- acmeReports_2.1.0.tar.gz
+`-- builds/
+```
+
+The fake `shiny-app/_shinyelectron.yml` would look like this:
 
 ```yaml
 dependencies:
@@ -53,24 +69,33 @@ dependencies:
       - github::owner/package@v1.2.0
 
       # Use an alias when the repository and R package names differ
-      - internaltools=github::company/internal-tools@main
+      - acmeTheme=github::acme-corp/acme-shiny-theme@main
 
       # Resolved relative to the Shiny app directory
-      - localmodel=local::../packages/localmodel
+      - acmeData=local::../packages/acmeData
 
       # A versioned local source archive works too
-      - reporting=local::../packages/reporting_2.1.0.tar.gz
+      - acmeReports=local::../packages/acmeReports_2.1.0.tar.gz
 ```
 
-Build these apps with the bundled strategy:
+The user can then build from any R working directory by using explicit paths:
 
 ```r
+project_dir <- "C:/Users/alex/Documents/acme-desktop"
+
 export(
-  appdir = "path/to/shiny-app",
-  destdir = "path/to/output",
-  runtime_strategy = "bundled"
+  appdir = file.path(project_dir, "shiny-app"),
+  destdir = file.path(project_dir, "builds", "acme-desktop-app"),
+  app_name = "Acme Analytics",
+  runtime_strategy = "bundled",
+  overwrite = TRUE
 )
 ```
+
+The `local::../packages/...` paths are evaluated from `shiny-app`, where the
+YAML file lives, not from the current R working directory. The resulting Windows
+installer is written beneath
+`builds/acme-desktop-app/electron-app/dist/`.
 
 Public GitHub and local packages require no credentials. Private GitHub
 repositories use `GITHUB_PAT` or `GH_TOKEN` from the build environment.

--- a/README.qmd
+++ b/README.qmd
@@ -34,6 +34,51 @@ not yet on CRAN and may have rough edges. **Not recommended for
 production applications at this time.**
 :::
 
+## Private and local R packages
+
+R packages do not need to be published on CRAN to ship with a desktop app.
+With `runtime_strategy = "bundled"`, shinyelectron can install packages
+directly from GitHub or the build machine and embed them in the app's private R
+library. End users do not need R, the original package directory, repository
+access, or credentials. Bundling is distribution, not source-code protection:
+installed package contents remain inspectable by a determined user.
+
+Declare package sources in `_shinyelectron.yml` beside `app.R`:
+
+```yaml
+dependencies:
+  r:
+    packages:
+      # Public GitHub repository; @ref may be a branch, tag, or commit
+      - github::owner/package@v1.2.0
+
+      # Use an alias when the repository and R package names differ
+      - internaltools=github::company/internal-tools@main
+
+      # Resolved relative to the Shiny app directory
+      - localmodel=local::../packages/localmodel
+
+      # A versioned local source archive works too
+      - reporting=local::../packages/reporting_2.1.0.tar.gz
+```
+
+Build these apps with the bundled strategy:
+
+```r
+export(
+  appdir = "path/to/shiny-app",
+  destdir = "path/to/output",
+  runtime_strategy = "bundled"
+)
+```
+
+Public GitHub and local packages require no credentials. Private GitHub
+repositories use `GITHUB_PAT` or `GH_TOKEN` from the build environment.
+Tokens are build-time secrets: they are not required by end users and must
+never be placed in app source, `_shinyelectron.yml`, or an installer.
+Relative local paths and pinned source archives are the simplest reproducible
+option for internal or corporate builds.
+
 ## Install
 
 ```r

--- a/tests/testthat/test-build-runtime.R
+++ b/tests/testthat/test-build-runtime.R
@@ -62,9 +62,9 @@ test_that("embed_r_runtime resolves the recursive closure minus pre_installed an
   expect_match(r_code, "runtime/R/library", fixed = TRUE)
 
   # Resolved set == recursive closure {shiny,htmltools,rlang} minus pre_installed {rlang}.
-  expect_match(r_code, "'shiny'", fixed = TRUE)
-  expect_match(r_code, "'htmltools'", fixed = TRUE)
-  expect_false(grepl("'rlang'", r_code, fixed = TRUE))
+  expect_match(r_code, '"shiny"', fixed = TRUE)
+  expect_match(r_code, '"htmltools"', fixed = TRUE)
+  expect_false(grepl('"rlang"', r_code, fixed = TRUE))
 })
 
 test_that("embed_r_runtime embeds the interpreter even when packages is empty", {

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -271,6 +271,44 @@ test_that("merge_r_dependencies includes extra_packages", {
   expect_true("shiny" %in% result$packages)
 })
 
+test_that("GitHub R package specs replace their auto-detected package name", {
+  config_deps <- list(
+    auto_detect = TRUE,
+    r = list(
+      packages = list("mypkg=github::me/my-repository@v1.2.0"),
+      repos = list("https://cloud.r-project.org")
+    )
+  )
+
+  result <- merge_r_dependencies(c("shiny", "mypkg"), config_deps)
+
+  expect_true("shiny" %in% result$packages)
+  expect_false("mypkg" %in% result$packages)
+  expect_true("mypkg=github::me/my-repository@v1.2.0" %in% result$packages)
+  expect_equal(
+    github_r_package_name("mypkg=github::me/my-repository@v1.2.0"),
+    "mypkg"
+  )
+})
+
+test_that("GitHub R package specs require bundled strategy", {
+  skip_if_not_installed("renv")
+  appdir <- withr::local_tempdir()
+  writeLines("library(mypkg)", file.path(appdir, "app.R"))
+  config <- list(dependencies = list(
+    auto_detect = TRUE,
+    r = list(
+      packages = list("mypkg=github::me/my-repository"),
+      repos = list("https://cloud.r-project.org")
+    )
+  ))
+
+  expect_error(
+    resolve_app_dependencies(appdir, "r-shiny", "auto-download", config),
+    "require the bundled runtime"
+  )
+})
+
 test_that("merge_py_dependencies combines detected and declared", {
   detected <- c("pandas", "numpy")
   config_deps <- list(

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -309,6 +309,23 @@ test_that("GitHub R package specs require bundled strategy", {
   )
 })
 
+test_that("local R package paths resolve relative to the app directory", {
+  root <- withr::local_tempdir()
+  appdir <- file.path(root, "app")
+  pkgdir <- file.path(root, "packages", "mypkg")
+  dir.create(appdir)
+  dir.create(pkgdir, recursive = TRUE)
+
+  resolved <- resolve_local_r_packages(
+    "mypkg=local::../packages/mypkg",
+    appdir
+  )
+
+  expect_equal(r_package_name(resolved), "mypkg")
+  expect_true(startsWith(resolved, "mypkg=local::"))
+  expect_true(grepl("packages/mypkg$", resolved))
+})
+
 test_that("merge_py_dependencies combines detected and declared", {
   detected <- c("pandas", "numpy")
   config_deps <- list(
@@ -338,6 +355,19 @@ test_that("generate_dependency_manifest creates valid JSON for R", {
   expect_true("shiny" %in% parsed$packages)
   expect_equal(parsed$repos[[1]], "https://cloud.r-project.org")
   expect_true(parsed$binary_only)
+})
+
+test_that("R manifest separates build sources from runtime package names", {
+  spec <- "mypkg=github::me/different-repository@v1"
+  manifest <- generate_dependency_manifest(
+    packages = c("shiny", spec),
+    language = "r",
+    repos = list("https://cloud.r-project.org")
+  )
+
+  parsed <- jsonlite::fromJSON(manifest, simplifyVector = FALSE)
+  expect_equal(unlist(parsed$packages), c("shiny", "mypkg"))
+  expect_equal(unlist(parsed$package_sources), c("shiny", spec))
 })
 
 test_that("generate_dependency_manifest creates valid JSON for Python", {

--- a/vignettes/configuration.qmd
+++ b/vignettes/configuration.qmd
@@ -312,6 +312,24 @@ These keys sit under `dependencies.r` and apply to the `bundled`, `auto-download
 | `r.repos` | list of strings | `["https://cloud.r-project.org"]` | CRAN-compatible repository URLs to use when installing R packages |
 | `r.lib_path` | string | `null` | Custom library path where R packages are installed; `null` uses the default R library |
 
+For bundled R apps, `r.packages` also accepts pak-style GitHub references.
+Use an explicit package-name alias when the repository name differs from the
+R package name:
+
+```yaml
+dependencies:
+  r:
+    packages:
+      - github::owner/package
+      - mypkg=github::owner/repository@v1.2.0
+    repos:
+      - https://cloud.r-project.org
+```
+
+The optional `@ref` may be a branch, tag, or commit. Private repositories use
+`GITHUB_PAT` or `GH_TOKEN` from the build environment. GitHub references
+currently require `runtime_strategy: bundled`.
+
 #### Python-specific dependency options
 
 These keys sit under `dependencies.python` and apply to the `bundled`, `auto-download`, and `system` strategies.

--- a/vignettes/configuration.qmd
+++ b/vignettes/configuration.qmd
@@ -312,9 +312,10 @@ These keys sit under `dependencies.r` and apply to the `bundled`, `auto-download
 | `r.repos` | list of strings | `["https://cloud.r-project.org"]` | CRAN-compatible repository URLs to use when installing R packages |
 | `r.lib_path` | string | `null` | Custom library path where R packages are installed; `null` uses the default R library |
 
-For bundled R apps, `r.packages` also accepts pak-style GitHub references.
-Use an explicit package-name alias when the repository name differs from the
-R package name:
+For bundled R apps, `r.packages` also accepts pak-style GitHub and local
+package references. Use an explicit package-name alias when the repository
+name differs from the R package name. Local paths are resolved relative to the
+directory containing the Shiny app:
 
 ```yaml
 dependencies:
@@ -322,13 +323,16 @@ dependencies:
     packages:
       - github::owner/package
       - mypkg=github::owner/repository@v1.2.0
+      - internaltools=local::../packages/internaltools
     repos:
       - https://cloud.r-project.org
 ```
 
 The optional `@ref` may be a branch, tag, or commit. Private repositories use
-`GITHUB_PAT` or `GH_TOKEN` from the build environment. GitHub references
-currently require `runtime_strategy: bundled`.
+`GITHUB_PAT` or `GH_TOKEN` from the build environment. Local sources may be
+package directories or package archives. GitHub and local references currently
+require `runtime_strategy: bundled`; the installed package is embedded, and
+the source path is not needed on the end user's computer.
 
 #### Python-specific dependency options
 


### PR DESCRIPTION
Description
Summary
This PR allows bundled R Shiny applications to use packages that are not published on CRAN.
Supported package sources include:
Public or private GitHub repositories
Local R package directories
Local source archives such as .tar.gz files
Example
dependencies:
  r:
    packages:
      - github::owner/package@v1.2.0
      - CustomName=github::owner/repository@main
      - InternalPackage=local::../packages/InternalPackage
      - Reports=local::../packages/Reports_2.1.0.tar.gz
Relative local paths are resolved from the Shiny application directory.
Implementation
Uses pak::pkg_install() when constructing the bundled R library.
Separates build-time package specifications from runtime package names.
Removes local paths and GitHub references from the packaged runtime manifest.
Supports GITHUB_PAT and GH_TOKEN for private GitHub repositories.
Does not embed repository credentials in the resulting application.
Requires runtime_strategy = "bundled" for GitHub and local packages.
Supports both single-app and multi-app builds.
Adds documentation and tests covering package specifications, manifests, and path resolution.
Motivation
Many Shiny applications depend on internal packages or development versions that are intentionally not published to CRAN. These packages should be installable while constructing the application’s private R library.
Once built, end users do not need:
R installed
Access to the GitHub repository
The original local package directory
Build credentials
Validation
Dependency-handling tests pass.
Diff whitespace validation passes.
Runtime-mocking tests were skipped locally because mockery was unavailable.
Network-backed system-requirement checks warned because network access was unavailable.
This PR is intentionally separate from the sitrep crash investigation and Node PATH fix.